### PR TITLE
Feature/sanne/detail page setup

### DIFF
--- a/src/lib/components/molecules/HeaderContent.svelte
+++ b/src/lib/components/molecules/HeaderContent.svelte
@@ -1,30 +1,25 @@
 <script>
   import IconLocation from '../atoms/IconLocation.svelte'
   export let items
-  console.log(items[0].componentsCollection)
 </script>
 
-{#each items as item}
-  <section class="content-container">
-    <!-- First content row -->
-    <div class="title-label">
-      <h1>{item.title}</h1>
-      <span class="label" aria-hidden="true">{item.label}</span>
-    </div>
+<section class="content-container">
+  <!-- First content row -->
+  <div class="title-label">
+    <h1>{items.title}</h1>
+    <span class="label" aria-hidden="true">{items.label}</span>
+  </div>
 
-    <!-- Second content row -->
-    <h2 class="subtitle">
-      {item.subtitle}
-    </h2>
+  <!-- Second content row -->
+  <h2 class="subtitle">{items.subtitle}</h2>
 
-    <!-- Last content row -->
-    <div class="location-price">
-      <IconLocation width="15" height="15" color="hsl(21.23, 100%, 87.25%)" />
-      <p class="location">{item.location}</p>
-      <p class="price">{item.price}</p>
-    </div>
-  </section>
-{/each}
+  <!-- Last content row -->
+  <div class="location-price">
+    <IconLocation width="15" height="15" color="hsl(21.23, 100%, 87.25%)" />
+    <p class="location">{items.location}</p>
+    <p class="price">€{items.price}</p>
+  </div>
+</section>
 
 <style>
   .content-container {
@@ -38,7 +33,7 @@
   h1 {
     display: flex;
     align-items: center;
-    font-size: 2rem;
+    font-size: 1.9rem;
     text-transform: uppercase;
     color: white;
   }
@@ -61,7 +56,7 @@
 
   /* Second content row */
   .subtitle {
-    font-size: 2rem;
+    font-size: 1.9rem;
     text-transform: uppercase;
     color: white;
   }

--- a/src/lib/components/molecules/HeaderContent.svelte
+++ b/src/lib/components/molecules/HeaderContent.svelte
@@ -1,49 +1,30 @@
 <script>
   import IconLocation from '../atoms/IconLocation.svelte'
-
-  // Mockdata voor de header text
-  const mockData = [
-    {
-      title: 'Regular',
-      subtitle: 'cocktail walk',
-      label: 'route 1',
-      location: 'Center, West',
-      price: '€25,95',
-    },
-    {
-      title: 'Premium',
-      subtitle: 'cocktail walk',
-      label: 'route 2',
-      location: 'Center, West',
-      price: '€26,95',
-    },
-    {
-      title: 'Bols',
-      subtitle: 'cocktail walk',
-      label: 'route 3',
-      location: 'Center, West',
-      price: '€29,95',
-    },
-  ]
+  export let items
+  console.log(items[0].componentsCollection)
 </script>
 
-<section class="content-container">
-  <!-- First content row -->
-  <div class="title-label">
-    <h1>{mockData[0].title}</h1>
-    <span class="label" aria-hidden="true">{mockData[0].label}</span>
-  </div>
+{#each items as item}
+  <section class="content-container">
+    <!-- First content row -->
+    <div class="title-label">
+      <h1>{item.title}</h1>
+      <span class="label" aria-hidden="true">{item.label}</span>
+    </div>
 
-  <!-- Second content row -->
-  <h1 class="subtitle">{mockData[0].subtitle}</h1>
+    <!-- Second content row -->
+    <h2 class="subtitle">
+      {item.subtitle}
+    </h2>
 
-  <!-- Last content row -->
-  <div class="location-price">
-    <IconLocation width="15" height="15" color="hsl(21.23, 100%, 87.25%)" />
-    <p class="location">{mockData[0].location}</p>
-    <p class="price">{mockData[0].price}</p>
-  </div>
-</section>
+    <!-- Last content row -->
+    <div class="location-price">
+      <IconLocation width="15" height="15" color="hsl(21.23, 100%, 87.25%)" />
+      <p class="location">{item.location}</p>
+      <p class="price">{item.price}</p>
+    </div>
+  </section>
+{/each}
 
 <style>
   .content-container {

--- a/src/lib/components/organisms/HeaderDetailPage.svelte
+++ b/src/lib/components/organisms/HeaderDetailPage.svelte
@@ -8,7 +8,7 @@
 <div class="header-container">
   <HeaderImage src="" opacity="0.2" alt="cocktail" />
   <div class="header-text">
-    <HeaderContent {items} />
+    <HeaderContent items={items[0].componentsCollection.items[0]} />
   </div>
 </div>
 

--- a/src/lib/components/organisms/HeaderDetailPage.svelte
+++ b/src/lib/components/organisms/HeaderDetailPage.svelte
@@ -1,12 +1,14 @@
 <script>
   import HeaderContent from '../molecules/HeaderContent.svelte'
   import HeaderImage from '../atoms/HeaderImage.svelte'
+  export let items
+  console.log(items)
 </script>
 
 <div class="header-container">
-  <HeaderImage src={'header-image-large.webp'} opacity="0.2" alt="cocktail" />
+  <HeaderImage src="" opacity="0.2" alt="cocktail" />
   <div class="header-text">
-    <HeaderContent />
+    <HeaderContent {items} />
   </div>
 </div>
 

--- a/src/lib/components/organisms/footer.svelte
+++ b/src/lib/components/organisms/footer.svelte
@@ -1,7 +1,6 @@
 <script>
   import { Link, Image, Button } from '$lib/index'
   export let footerItems
-  console.log(footerItems)
 </script>
 
 <footer>

--- a/src/lib/components/pages/Home.svelte
+++ b/src/lib/components/pages/Home.svelte
@@ -6,7 +6,7 @@
 {#each items[1].itemsCollection.items as item}
   <div class="container-card">
     <h2>{item.title}</h2>
-    <a href="/tickets/{item.slug}">Koop een ticket!</a>
+    <a href="/home/{item.slug}">Koop een ticket!</a>
   </div>
 {/each}
 

--- a/src/lib/components/pages/Home.svelte
+++ b/src/lib/components/pages/Home.svelte
@@ -1,15 +1,24 @@
 <script>
-  // export let items
+  import { Card } from '$lib/index'
+  export let items
 </script>
 
-<h1>Homepage</h1>
+{#each items[1].itemsCollection.items as item}
+  <div class="container-card">
+    <h2>{item.title}</h2>
+    <a href="/tickets/{item.slug}">Koop een ticket!</a>
+  </div>
+{/each}
+
+<!-- <Card />
+<a href="/tickets/regulair">Regulair ticket</a> -->
 
 <svelte:head>
   <title></title>
 </svelte:head>
 
 <style>
-  h1 {
+  h2 {
     color: red;
   }
 </style>

--- a/src/lib/components/pages/TicketInfoPage.svelte
+++ b/src/lib/components/pages/TicketInfoPage.svelte
@@ -1,5 +1,7 @@
 <script>
   import HeaderDetailPage from '../organisms/HeaderDetailPage.svelte'
+  export let items
+  console.log(items, 'test ticket info page')
 </script>
 
 <HeaderDetailPage />

--- a/src/lib/components/pages/TicketInfoPage.svelte
+++ b/src/lib/components/pages/TicketInfoPage.svelte
@@ -1,7 +1,11 @@
 <script>
   import HeaderDetailPage from '../organisms/HeaderDetailPage.svelte'
-  export let items
-  console.log(items, 'test ticket info page')
+  export let data
+  console.log(data)
 </script>
 
-<HeaderDetailPage />
+<svelte:head>
+  <title></title>
+</svelte:head>
+
+<HeaderDetailPage items={data.pageData} />

--- a/src/lib/components/pages/WorkWithUs.svelte
+++ b/src/lib/components/pages/WorkWithUs.svelte
@@ -1,6 +1,5 @@
 <script>
   // export let items
-  // console.log(items)
 </script>
 
 <h1>Work with us page bars</h1>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
 <header>
   <Navigation navigationItems={data.navigation} />
 </header>
-<TicketInfoPage />
+<!-- <TicketInfoPage /> -->
 
 <main id="main">
   <slot />

--- a/src/routes/[slug]/[slug]/+page.server.js
+++ b/src/routes/[slug]/[slug]/+page.server.js
@@ -21,18 +21,6 @@ export async function load({ params }) {
                 title
               }   
             }
-          ... on ItemCollection {
-            itemsCollection(limit: 4) {
-              items {
-                ... on Card{
-                  title
-                  textParagraph
-                  price
-                  slug
-                }
-              }
-            }
-          }
           }
         }
       }
@@ -41,7 +29,6 @@ export async function load({ params }) {
   `
 
   const response = await contentfulFetch(query)
-
   const { data } = await response.json()
   const { items } = data.pageCollection
 

--- a/src/routes/[slug]/[slug]/+page.server.js
+++ b/src/routes/[slug]/[slug]/+page.server.js
@@ -30,6 +30,7 @@ export async function load({ params }) {
 
   const response = await contentfulFetch(query)
   const { data } = await response.json()
+  console.log(data.pageCollection,'test data')
   const { items } = data.pageCollection
 
   if (!items || items.length === 0) {

--- a/src/routes/[slug]/[slug]/+page.svelte
+++ b/src/routes/[slug]/[slug]/+page.svelte
@@ -2,17 +2,12 @@
   import { TicketInfoPage } from '$lib/index'
   export let data
 
-  const componentMap = {
-    home: HomePage,
-    'ticket-information': TicketInfoPage,
-  }
-  const items = data.pageData.find((pageDataItem) => pageDataItem.slug === data.slug)
-    .componentsCollection.items
-
-  const Component = componentMap[data.slug] || TicketInfoPage
+  // const currentPageData = data.pageData?.[0] || {}
+  // const { componentsCollection: { items = [] } = {}, slug = '' } = currentPageData
+  // ;('')
 </script>
 
-<svelte:component this={Component} {items} />
+<TicketInfoPage {data} />
 
 <style>
 </style>

--- a/src/routes/[slug]/[slug]/+page.svelte
+++ b/src/routes/[slug]/[slug]/+page.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { TicketInfoPage } from '$lib/index'
+  export let data
+
+  const componentMap = {
+    home: HomePage,
+    'ticket-information': TicketInfoPage,
+  }
+  const items = data.pageData.find((pageDataItem) => pageDataItem.slug === data.slug)
+    .componentsCollection.items
+
+  const Component = componentMap[data.slug] || TicketInfoPage
+</script>
+
+<svelte:component this={Component} {items} />
+
+<style>
+</style>


### PR DESCRIPTION
## What does this change?
This change ensures that the different detail pages load by clicking the corresponding link, using a [slug] in a [slug] folder. As a result, I can finally fetch data and I no longer need to use mockdata. 🥳 

## How Has This Been Tested?

- [x] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test
