### PR TITLE
Verbetering HTML & Layout responsive en toegankelijkheid voor cardlijst

### DIFF
--- a/src/lib/components/atoms/Image.svelte
+++ b/src/lib/components/atoms/Image.svelte
@@ -18,7 +18,7 @@
 
 <style>
   img {
-    /* object-fit: cover; */
+    object-fit: cover;
     width: 100%;
     height: 100%;
     display: block;

--- a/src/lib/components/atoms/Image.svelte
+++ b/src/lib/components/atoms/Image.svelte
@@ -18,7 +18,7 @@
 
 <style>
   img {
-   object-fit: cover;
+    /* object-fit: cover; */
     width: 100%;
     height: 100%;
     display: block;

--- a/src/lib/components/organisms/AnimationCard.svelte
+++ b/src/lib/components/organisms/AnimationCard.svelte
@@ -4,50 +4,108 @@
 </script>
 
 <section>
-  {#each items[2].componentsCollection.items as item, index}
-    <article>
-      <div>
-        <h3><span>{index + 1}</span>{item.title}</h3>
-        <p>{item.textParagraph}</p>
-      </div>
-      <Image src={item.image.url} alt="iphone" width="" height=""></Image>
-    </article>
-  {/each}
+  <ul>
+    {#each items[2].componentsCollection.items as item, index}
+      <li class="card-list card-number">
+        <div class="card-body">
+          <div class="image-container">
+            <Image src={item.image.url} alt="iphone" width="" height=""></Image>
+          </div>
+          <div class="text-content">
+            <h3><span>{index + 1}</span>{item.title}</h3>
+            <p>{item.textParagraph}</p>
+          </div>
+        </div>
+      </li>
+    {/each}
+  </ul>
 </section>
 
 <style>
   section {
-    max-width: 80%;
+    background: green;
+    --cards: 4;
+    --cardHeight: 87vh;
+    --cardTopPadding: 1.5em;
+    --cardMargin: 4vw;
+    width: 90%;
     margin: 0 auto;
   }
 
-  article {
+  ul {
+    background-color: red;
+    list-style: none;
+    padding-left: 0;
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(var(--cards), var(--cardHeight));
+    gap: var(--cardMargin);
+    padding-bottom: calc(var(--cards) * var(--cardTopPadding));
+    margin-bottom: var(--cardMargin);
+  }
+
+  .card-list {
+    background-color: purple;
     position: sticky;
-    top: 20px;
-    background-color: var(--accent2-tertiary);
-    color: var(--page-bg-color);
-    padding: 2.5rem;
-    border-radius: 10px;
+    top: 0;
+    padding-top: calc(var(--index) * var(--cardTopPadding));
+  }
+
+  .card-number:nth-child(1) {
+    --index: 1;
+  }
+  .card-number:nth-child(2) {
+    --index: 2;
+  }
+  .card-number:nth-child(3) {
+    --index: 3;
+  }
+  .card-number:nth-child(4) {
+    --index: 4;
+  }
+
+  .card-number:nth-child(1) .card-body {
+    background-color: #ffe5d9;
+  }
+  .card-number:nth-child(2) .card-body {
+    background-color: #ffd6c5;
+  }
+  .card-number:nth-child(3) .card-body {
+    background-color: #cab2a6;
+  }
+  .card-number:nth-child(4) .card-body {
+    background-color: #cba38f;
+  }
+
+  .card-number .card-body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .card-body {
+    background-color: orange;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: var(--cardHeight);
+    padding: 30px;
+    border-radius: 50px;
+    box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.3);
     transition: all 0.5s;
   }
 
-  article:nth-child(1) {
-    background-color: #ffe5d9;
-  }
-
-  article:nth-child(2) {
-    background-color: #ffd6c5;
-    top: 130px;
-  }
-  article:nth-child(3) {
-    background-color: #cab2a6;
-    top: 230px;
-  }
-  article:nth-child(4) {
-    background-color: #cba38f;
-    top: 330px;
+  .image-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: auto;
+    min-width: 200px;
+    max-width: 300px;
+    overflow: hidden;
   }
 
   h3 {
@@ -57,11 +115,9 @@
     padding: 1rem 0;
     font-weight: 700;
   }
+
   span {
     font-size: 16px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
     background-color: var(--page-bg-color);
     width: 24px;
     height: 24px;
@@ -70,12 +126,16 @@
   }
 
   @media (min-width: 48em) {
-    h3 {
-      font-size: 32px;
+    .card-number .card-body {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
     }
-    p {
-      padding: 1rem 0;
-      font-size: 24px;
+
+    .text-content {
+      text-align: right;
+      padding-right: 20px;
     }
   }
 </style>

--- a/src/lib/components/organisms/AnimationCard.svelte
+++ b/src/lib/components/organisms/AnimationCard.svelte
@@ -7,12 +7,15 @@
   <ul>
     {#each items[2].componentsCollection.items as item, index}
       <li class="card-list card-number">
-        <div class="card-body">
+        <div class="card-body" tabIndex="0">
           <div class="image-container">
-            <Image src={item.image.url} alt="iphone" width="" height=""></Image>
+            <Image src={item.image.url} alt={item.image.title} width="" height=""></Image>
           </div>
           <div class="text-content">
-            <h3><span>{index + 1}</span>{item.title}</h3>
+            <div class="span-cirkel">
+              <span aria-label="Step {index + 1}">{index + 1}</span>
+              <h3>{item.title}</h3>
+            </div>
             <p>{item.textParagraph}</p>
           </div>
         </div>
@@ -23,7 +26,6 @@
 
 <style>
   section {
-    background: green;
     --cards: 4;
     --cardHeight: 87vh;
     --cardTopPadding: 1.5em;
@@ -33,7 +35,6 @@
   }
 
   ul {
-    background-color: red;
     list-style: none;
     padding-left: 0;
     display: grid;
@@ -45,7 +46,6 @@
   }
 
   .card-list {
-    background-color: purple;
     position: sticky;
     top: 0;
     padding-top: calc(var(--index) * var(--cardTopPadding));
@@ -65,33 +65,26 @@
   }
 
   .card-number:nth-child(1) .card-body {
-    background-color: #ffe5d9;
+    background-color: #ffd6c5;
   }
   .card-number:nth-child(2) .card-body {
     background-color: #ffd6c5;
   }
   .card-number:nth-child(3) .card-body {
-    background-color: #cab2a6;
+    background-color: #ffd6c5;
   }
   .card-number:nth-child(4) .card-body {
-    background-color: #cba38f;
-  }
-
-  .card-number .card-body {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    background-color: #ffd6c5;
   }
 
   .card-body {
-    background-color: orange;
     display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
+    gap: 3.5rem;
     height: var(--cardHeight);
-    padding: 30px;
+    padding: 2rem;
     border-radius: 50px;
     box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.3);
     transition: all 0.5s;
@@ -101,41 +94,71 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    width: 100%;
-    height: auto;
+    width: 70%;
     min-width: 200px;
     max-width: 300px;
     overflow: hidden;
+  }
+
+  .text-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .span-cirkel {
+    display: flex;
+    flex-direction: row;
+    gap: 0.5em;
   }
 
   h3 {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 1rem 0;
+    font-size: 1.3rem;
     font-weight: 700;
   }
 
+  p {
+    font-size: 1.2rem;
+    font-weight: 500;
+  }
+
   span {
+    width: 25px;
+    height: 25px;
+    line-height: 25px;
+    border-radius: 50%;
+    text-align: center;
+    font-weight: bold;
     font-size: 16px;
     background-color: var(--page-bg-color);
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
     color: var(--accent2-quaternary);
   }
 
   @media (min-width: 48em) {
-    .card-number .card-body {
-      display: flex;
-      flex-direction: row;
-      justify-content: center;
-      align-items: center;
+    .card-body {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 3rem;
+      place-items: center;
     }
 
-    .text-content {
-      text-align: right;
-      padding-right: 20px;
+    h3 {
+      font-size: 2rem;
+    }
+
+    p {
+      font-size: 1.5rem;
+      padding: 0 2rem;
+    }
+
+    span {
+      width: 35px;
+      height: 35px;
+      line-height: 35px;
     }
   }
 </style>

--- a/static/global.css
+++ b/static/global.css
@@ -18,11 +18,6 @@ h1, h2, h3, h4, h5, h6 {
   letter-spacing: .2em;
 }
 
-p {
-  letter-spacing: .1em;
-
-}
-
 
 
   /* CSS variables inspired by https://open-props.style/ */


### PR DESCRIPTION
## What does this change?

[Resolves issue](https://github.com/users/mcphendriks/projects/17/views/19?pane=issue&itemId=56616356)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

- De article elementen zijn vervangen door ul en li elementen voor een semantisch correctere weergave van een lijst.
- een tabIndex="0" toegevoegd om de cards focusbaar te maken met toetsenbordnavigatie.
- aria-label aan de index span om duidelijker te maken dat het om een stapnummer gaat.



<img width="895" alt="Screenshot 2024-06-04 at 22 12 29" src="https://github.com/fdnd-agency/wogo/assets/106346778/e89015c4-0536-452b-a53e-4b2bd40eb030">


**TODO:**
Wanneer een asset wordt toegevoegd in Contentful, wordt deze bij elke kaart weergegeven in plaats van alleen bij de specifieke kaart waarvoor deze bedoeld is? Ik gebruik precies dezelfde data van de card voor de carousel en hier gebeurt het niet? 

Query: 

```
image {
... on Asset {
    url
    title
   }
 }
```



Still to do: 

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [x] Device test
- [x] Browser test 

## Images

Old
<img width="200" alt="Screenshot 2024-06-04 at 21 23 43" src="https://github.com/fdnd-agency/wogo/assets/106346778/b32094fb-f3e8-4208-be79-20fc287638f5">

New
<img width="200" alt="Screenshot 2024-06-04 at 21 25 29" src="https://github.com/fdnd-agency/wogo/assets/106346778/2f0268dc-510d-40fb-9368-b2db2c48d0ed">

<img width="200" alt="Screenshot 2024-06-04 at 21 25 45" src="https://github.com/fdnd-agency/wogo/assets/106346778/6aeb536b-b4c9-45a5-ba43-6665ffa734fc">

Mobile: 
<img width="200" alt="Screenshot 2024-06-04 at 21 25 45" src="https://github.com/fdnd-agency/wogo/assets/106346778/1c89f04c-662c-479e-8de2-8a01ab643615">

## How to review

Is dit een goede beschrijving voor het aria-label voor de screenreader: "Phone screen displaying the booking process for a walk"? Ik vind dit beter dan "books a walk" als aria-label omdat de screenreader dan niet duidelijk maakt dat het om een afbeelding gaat.

<img width="200" alt="Screenshot 2024-06-04 at 21 10 22" src="https://github.com/fdnd-agency/wogo/assets/106346778/cc80ffd3-a495-43fd-8c11-85fd2c5310e5">



<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
