### PR TITLE
Build: add poster attribuut for performance issue LCP(video inladen)

### DIFF
--- a/src/lib/components/organisms/Hero.svelte
+++ b/src/lib/components/organisms/Hero.svelte
@@ -4,7 +4,14 @@
 </script>
 
 <section>
-  <video autoplay muted loop aria-label="">
+  <video
+    autoplay
+    muted
+    loop
+    aria-label={items.description}
+    aria-hidden="true"
+    poster="/hero-image-background.webp"
+  >
     <source src={items[0].asset.url} type="video/mp4" />
   </video>
   <div class="hero-content">

--- a/src/routes/[slug]/+page.server.js
+++ b/src/routes/[slug]/+page.server.js
@@ -18,7 +18,7 @@ export async function load({ params }) {
               location
               asset {
                 url
-                title
+                description
               }   
             }
           ... on ItemCollection {


### PR DESCRIPTION
## What does this change?

Resolves issue #101 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Ik heb een poster attribuut toegevoegd aan het video element om de presentatie probleem om te lossen(in overleg met Krijn)  doordat een afbeelding snel wordt weergegeven, wordt laadtijd vermindert.

Daarnaast heb ik het video bestand verkleind van:

Original Size: 128,781,190 bytes (128.8 MB on disk)
New Size: 5,631,938 bytes (5.6 MB on disk)


[livesite](https://livesite.com)

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


Het probleem was dat er eerst 5 hero-sectie items waren, maar nu worden er nog maar 2 weergegeven, en zelfs dit is nog niet perfect. Ik weet niet precies hoe ik dit probleem moet oplossen. Ik heb ook een animatie op de ```<h1>``` die later inlaadt. Misschien kan dit problemen veroorzaken voor de Largest Contentful Paint (LCP)?(Animatie is gebouwd met CSS)

<img width="758" alt="Screenshot 2024-06-04 at 22 46 13" src="https://github.com/fdnd-agency/wogo/assets/106346778/6241c805-e47d-42b7-b3f1-95dd66ab022c">


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
