### PR TITLE
Herstellen van navigatiedata door query aan te passen

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,6 @@
     "tabWidth": 2,
     "useTabs": false,
     "singleQuote": true,
-    "trailingComma": "es5",
     "semi": false,
     "printWidth": 100 
   }

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -1,7 +1,8 @@
 <script>
   import { Link, Image, CartIcon, BaseButton, ArrowDown } from '$lib/index'
   import logo from '$lib/assets/Logo.png'
-  export let navigationItems
+  export let navigation
+  console.log(navigation)
 </script>
 
 <header>
@@ -19,7 +20,7 @@
   <button type="button" id="mainMenuOpen" tabindex="-1"><span></span></button>
   <nav>
     <ul>
-      {#each navigationItems[0].navigationLinksCollection.items as link}
+      {#each navigation.navigationLinksCollection.items as link}
         {#if link.title === 'More'}
           <li class="more-button">
             <BaseButton

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -4,11 +4,10 @@ import contentfulFetch from '../api/contentful-fetch'
 
 const query = `
 {
-  navigationCollection(limit: 1) {
-    items {
-    navigationLinksCollection(limit: 5) {
-        items {
-          ... on TypeLink {
+  navigation(id: "4xhowg37MDjXP7okbSrx1b") {
+    navigationLinksCollection {
+      items {
+         ... on TypeLink {
            title
            label
           	slug
@@ -26,7 +25,6 @@ const query = `
         }
       }
     }
-  }
 
   footerCollection(limit: 1) {
     items {
@@ -70,14 +68,11 @@ const query = `
       })
     }
     const { data } = await response.json()
-    const { items: navigationItems } = data.navigationCollection
+    const { navigation } = data
     const { items: footerItems } = data.footerCollection
-    // const { items: tabBarItems } = data.tabBarCollection
-    
     
     return {
-      navigation: navigationItems,
-      footer: footerItems,
-      // tabBar: tabBarItems,
-    }
+      navigation,
+      footer: footerItems
+    };
   }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,10 @@
 <script>
   import { Header, Footer } from '$lib/index'
   export let data
+  console.log(data)
 </script>
 
-<Header navigationItems={data.navigation} />
+<Header navigation={data.navigation} />
 
 <main id="main">
   <slot />


### PR DESCRIPTION
## What does this change?

Resolves issue #1337

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

<img width="1368" alt="Screenshot 2024-06-08 at 18 52 16" src="https://github.com/fdnd-agency/wogo/assets/106346778/cb8e9817-aeb4-4789-a235-2998651df3a9">






Probleem: 

Bij de vorige implementatie van de GraphQL-query werd een navigationCollection met een limiet van 1 gebruikt, waardoor alleen de eerste set navigatielinks (de tabbar links) werden opgehaald en weergegeven. Hierdoor ontbraken de header-navigatielinks in de applicatie.


Oplossing
Ik had dit probleem kunnen oplossen door het verwijderen van de limiet op navigationCollection, dit zou dan ervoor zorgen dat zowel de navigatielinks in de header en tabbar worden opgehaald, maar dit kan voor verwarring zorgen(zoals nu onstand). Door specifieke ID's te gebruiken voor zowel de header als de tabbar, kunnen we de navigatiegegevens georganiseerd en duidelijk gescheiden houden. 



[livesite](https://wogo.netlify.app/home)

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images


Toonde data van de TabBar:
<img width="1668" alt="Screenshot 2024-06-08 at 17 57 04" src="https://github.com/fdnd-agency/wogo/assets/106346778/eeb81e75-d7d2-48f2-8fb2-7276c9b9ab04">

Navbar na (Specifieke ID voor navigatie)

<img width="1343" alt="Screenshot 2024-06-08 at 19 01 36" src="https://github.com/fdnd-agency/wogo/assets/106346778/f2f17055-155f-4bc8-8243-e7049b836e01">



## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
