### PR TITLE
Feature/michelle/performance/fix layout shifting

### DIFF
--- a/src/lib/components/molecules/TicketCard.svelte
+++ b/src/lib/components/molecules/TicketCard.svelte
@@ -48,6 +48,7 @@
   }
 
   div:first-of-type {
+    min-height: 200px;
     position: relative;
   }
 
@@ -61,6 +62,7 @@
     font-size: 2em;
     line-height: 1em;
     color: var(--txt-quaternary-clr);
+    min-height: 2.5em;
   }
 
   div:first-of-type p {
@@ -69,10 +71,11 @@
     top: 1em;
     margin: 0;
     padding: 0.2rem 0.5rem;
-    font-weight: bold;
+    font-weight: 800;
     border-radius: var(--radius-lg);
     color: var(--txt-quaternary-clr);
     background-color: var(--accent2-primary);
+    min-height: 1.5em;
   }
 
   p {

--- a/src/lib/components/molecules/TicketCard.svelte
+++ b/src/lib/components/molecules/TicketCard.svelte
@@ -48,7 +48,8 @@
   }
 
   div:first-of-type {
-    min-height: 200px;
+    height: 100%;
+    min-height: 4em;
     position: relative;
   }
 


### PR DESCRIPTION
## What does this change?

Layout shifts op de pagina veroorzaken een slechte gebruikerservaring en verhogen de (CLS) score. de titel (`h3`) en de prijs (`p`) verschuiven tijdens het laden van de pagina.

**Oplossing:**
- Vaste hoogtes toegevoegd aan de titel (`h3`) en de prijs (`p`) om ruimte voor deze elementen te reserveren en layout shifts te verminderen.
- CSS bijgewerkt om deze wijzigingen te weerspiegelen.

<img width="507" alt="Screenshot 2024-06-09 at 09 53 04" src="https://github.com/fdnd-agency/wogo/assets/106346778/5ff70eb9-5843-46b7-a6fd-5f2f4b85f272">



<img width="759" alt="Screenshot 2024-06-09 at 10 29 55" src="https://github.com/fdnd-agency/wogo/assets/106346778/27f4a2cd-659f-4672-adad-4f556e741394">

Resolves issue #1337

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
