### PR TITLE
Fix: drop-shadow and font-size

### DIFF
--- a/src/lib/components/atoms/Link.svelte
+++ b/src/lib/components/atoms/Link.svelte
@@ -8,12 +8,13 @@
   export let iconWidth = '24px'
   export let iconHeight = '24px'
   export let iconColor = ''
+  export let filter = ''
 </script>
 
 <a
   {href}
   data-sveltekit-preload-data
-  style="--clr: {color}; --font-size: {fontSize}"
+  style="--clr: {color}; --font-size: {fontSize}; --filter: {filter};"
   aria-label={ariaLabel}
 >
   {title}
@@ -29,12 +30,12 @@
   a {
     display: flex;
     align-items: center;
-    vertical-align: middle;
     gap: 0.5rem;
     text-decoration: none;
     color: var(--clr);
     font-size: var(--font-size);
     white-space: nowrap;
+    filter: var(--filter);
   }
 
   span {

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -41,7 +41,6 @@
                     href={sublink.slug}
                     title={sublink.title}
                     aria-label={sublink.label}
-                    size="lg"
                     color="var(--txt-dark-clr)"
                   />
                 </li>
@@ -54,8 +53,8 @@
               href={link.slug}
               title={link.title}
               arialabel={link.label}
-              size="lg"
               color="var(--txt-secondary-clr)"
+              filter="var(--filter-drop)"
             />
             {#if link.subLinksCollection.items.length > 0}
               <ul class="sub-menu" aria-label="Submenu">
@@ -65,7 +64,6 @@
                       href={sublink.slug}
                       title={sublink.title}
                       aria-label={sublink.label}
-                      size="lg"
                       color="var(--txt-dark-clr)"
                     />
                   </li>
@@ -123,6 +121,9 @@
 
   nav li {
     position: relative;
+    font-size: var(--fs-lg);
+    font-weight: 550;
+    padding: 0.5rem 1rem;
   }
   nav li:last-of-type {
     margin-left: 5px;
@@ -142,7 +143,7 @@
     top: 150%;
     left: 0;
     background-color: var(--accent2-tertiary);
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-md);
     overflow: hidden;
     opacity: 0;
     transform: translateY(-10px);
@@ -258,7 +259,7 @@
       display: flex;
       flex-direction: column;
       font-weight: 500;
-      font-size: 4em;
+      font-size: var(--fs-xl);
       padding: 1rem 0 1rem 0;
     }
 

--- a/src/lib/components/organisms/TicketCarousel.svelte
+++ b/src/lib/components/organisms/TicketCarousel.svelte
@@ -169,7 +169,6 @@
     width: 100%;
     display: flex;
     margin: 0 0 0 2rem;
-    width: calc(100% - 16px);
     overflow-x: auto;
     overflow-y: hidden;
     scroll-snap-type: x mandatory;

--- a/src/lib/components/organisms/TicketCarousel.svelte
+++ b/src/lib/components/organisms/TicketCarousel.svelte
@@ -162,6 +162,7 @@
     --arrow-size: 40px;
     width: 100%;
     position: relative;
+    overflow: hidden;
   }
 
   .card-container {

--- a/static/global.css
+++ b/static/global.css
@@ -95,6 +95,10 @@ h1, h2, h3, h4, h5, h6 {
     --fs-lg: clamp(1.35rem, calc(1.22rem + 0.64vw), 1.72rem);
     --fs-xl: clamp(1.94rem, calc(1.69rem + 1.29vw), 2.69rem);
     --fs-2xl: clamp(2.80rem, calc(2.31rem + 2.43vw), 4.20rem);
+
+    --filter-drop: drop-shadow(0 0 0.4rem #000);
+
+    --txt-shadow: 1px 1px 2px pink;
   
     /* line heights */
     --lh-1: 1;


### PR DESCRIPTION
## What does this change?

Resolves issue #1337

Ik heb een BaseButton-component waarin ik een logica heb om te bepalen of het een knop of een link moet zijn. Nu heb ik echter een apart Link-component gemaakt om de code schoner en begrijpelijker te houden. Soms heeft een link de stijl van een knop, maar het blijft een link. De navigatie-items in de navigatiebalk zijn wel links. Met deze aanpassing kan ik beter onderscheidt maken voor knoppen en links, waardoor de code onderhoudbaarder wordt.

Door bovenstaande verandering in de carousel klopt te font-size niet meer van de navigationbar, vandaar deze pull-request. 
